### PR TITLE
Fixes Symposium plugin query that uses ||

### DIFF
--- a/wp-includes/translations.php
+++ b/wp-includes/translations.php
@@ -305,8 +305,7 @@ class SQL_Translations extends wpdb
             'translate_insert_nulltime',
             'translate_incompat_data_type',
             'translate_create_queries',
-            'translate_specific',
-			'translate_plugin_symposium',
+            'translate_specific',			
         );
 
         // Perform translations and record query changes.
@@ -380,6 +379,13 @@ class SQL_Translations extends wpdb
 
 		// Handle NULL-safe equal to operator.
         	$query = str_replace( "<=>", "=", $query );
+		
+		/**		
+		* Symposium Pro
+		*/
+		if ($start_pos = stripos($query, '(t.topic_parent = 0 || p.topic_parent = 0)')) {
+			$query = substr_replace($query, '(t.topic_parent = 0 OR p.topic_parent = 0)', $start_pos, 42);
+		}
 
         /**
          * Akismet
@@ -1713,21 +1719,6 @@ class SQL_Translations extends wpdb
         return $query;
     }
 
-	 /**
-     * Replace || with OR in Symposium Plugin query
-     *
-     * @param string $query Query coming in
-     *
-     * @return string Translated Query
-     */
-	function translate_plugin_symposium($query) 
-	{
-		if ($start_pos = stripos($query, '(t.topic_parent = 0 || p.topic_parent = 0)')) {
-			$query = substr_replace($query, '(t.topic_parent = 0 OR p.topic_parent = 0)', $start_pos, 42);
-		}
-		
-		return $query;
-	}
 	
     /**
      * Given a first parenthesis ( ...will find its matching closing paren )

--- a/wp-includes/translations.php
+++ b/wp-includes/translations.php
@@ -306,6 +306,7 @@ class SQL_Translations extends wpdb
             'translate_incompat_data_type',
             'translate_create_queries',
             'translate_specific',
+			'translate_plugin_symposium',
         );
 
         // Perform translations and record query changes.
@@ -1712,6 +1713,22 @@ class SQL_Translations extends wpdb
         return $query;
     }
 
+	 /**
+     * Replace || with OR in Symposium Plugin query
+     *
+     * @param string $query Query coming in
+     *
+     * @return string Translated Query
+     */
+	function translate_plugin_symposium($query) 
+	{
+		if ($start_pos = stripos($query, '(t.topic_parent = 0 || p.topic_parent = 0)')) {
+			$query = substr_replace($query, '(t.topic_parent = 0 OR p.topic_parent = 0)', $start_pos, 42);
+		}
+		
+		return $query;
+	}
+	
     /**
      * Given a first parenthesis ( ...will find its matching closing paren )
      *


### PR DESCRIPTION
MySQL supports || for logical OR, T-SQL does not.  This adds a
translation function to wp-includes/translations.php to handle a case
where Symposium uses a || in query by replacing || with OR