### PR TITLE
Refactor $wpdb->_insert_replace_helper to use MERGE instead of REPLACE 

### DIFF
--- a/wp-includes/wp-db.php
+++ b/wp-includes/wp-db.php
@@ -1919,7 +1919,7 @@ class wpdb {
 		$on = implode(' AND ', $on);
 		$set = implode(', ', $set);
 		$keyFormat = implode(', ', $keyFormats); //if more than one key, looks like: keyCol1, keyCol2
-		$keyName = implode(', ', $keyNames);
+		$keyName = '[' . implode('], [', $keyNames) . ']';
 		//exa: $on == "sourceTable.keyCol1 = targetTable.keyCol1 AND sourceTable.keyCol2 = targetTable.keyCol2"
 		//exa: $set == "[field1] = %s, [field2] = %d"
 		$sql = "MERGE INTO $table WITH (HOLDLOCK) AS targetTable USING (SELECT $keyFormat) AS sourceTable ($keyName) ";

--- a/wp-includes/wp-db.php
+++ b/wp-includes/wp-db.php
@@ -1926,7 +1926,7 @@ class wpdb {
 		$sql .= "ON ($on) WHEN MATCHED THEN UPDATE SET $set WHEN NOT MATCHED THEN INSERT ($fields) VALUES ($formats);";
 		//Since there are the keyFormat and two sets of the original formats one for the UPDATE and one for the INSERT, 
 		//we need to concatenate the $keyFormats with 2 x $formats and $keyValues with 2 x $values arrays so that prepare can correctly match them up
-		$formats = array_merge($keyFormat, $formats, $formats);
+		
 		$values = array_merge($keyValue, $values, $values);
 	} else {
 		//INSERT

--- a/wp-includes/wp-db.php
+++ b/wp-includes/wp-db.php
@@ -1900,7 +1900,7 @@ class wpdb {
 
 			foreach($keyNames as $uqCol) {
 				if ($data[$uqCol] !== null) {
-					$keyValue[0] = $data[$uqCol]['value'];
+					$keyValues[0] = $data[$uqCol]['value'];
 					$keyFormats[0] = $data[$uqCol]['format'];
 					$on[0] = "sourceTable.[$uqCol] = targetTable.[$uqCol]";					
 				}
@@ -1925,9 +1925,8 @@ class wpdb {
 		$sql = "MERGE INTO $table WITH (HOLDLOCK) AS targetTable USING (SELECT $keyFormat) AS sourceTable ($keyName) ";
 		$sql .= "ON ($on) WHEN MATCHED THEN UPDATE SET $set WHEN NOT MATCHED THEN INSERT ($fields) VALUES ($formats);";
 		//Since there are the keyFormat and two sets of the original formats one for the UPDATE and one for the INSERT, 
-		//we need to concatenate the $keyFormats with 2 x $formats and $keyValues with 2 x $values arrays so that prepare can correctly match them up
-		
-		$values = array_merge($keyValue, $values, $values);
+		//we need to concatenate the $keyFormats with 2 x $formats and $keyValues with 2 x $values arrays so that prepare can correctly match them up		
+		$values = array_merge($keyValues, $values, $values);
 	} else {
 		//INSERT
 		$sql = "$type INTO [$table] ($fields) VALUES ($formats)";


### PR DESCRIPTION
This commit closes #105 by changing the generated SQL in the wpdb class's _insert_replace_helper function 

- from MySQL's REPLACE INTO 

- to a MERGE INTO statement which INSERTS or UPDATES depending on a matching row being found in the specified table.