### PR TITLE
Update translations.php

### DIFF
--- a/wp-includes/translations.php
+++ b/wp-includes/translations.php
@@ -1244,7 +1244,7 @@ class SQL_Translations extends wpdb
     function translate_sort_casting($query)
     {
         if ( stripos($query, 'ORDER') > 0 ) {
-            $ord = '';
+            $ord = strlen($query);
             $order_pos = stripos($query, 'ORDER');
             if ( stripos($query, 'BY', $order_pos) == ($order_pos + 6) && stripos($query, 'OVER(', $order_pos - 5) != ($order_pos - 5)) {
                 $ob = stripos($query, 'BY', $order_pos);


### PR DESCRIPTION
$ord should not be initialized to string type when used as an integer. Bad use of weak type.
Order direction ASC|DESC is optional in SQL, defaulting to ascending when omitted. Using a valid query as "... ORDER BY col1" will bypass both tests for "ASC" and "DESC" and throw an empty string $ord into the substring length parameter causing a PHP warning about non numeric input.
Proposed change sets the index position to the tail end of the "ORDER BY" parameters, in fact tail end of the query.
Note: proposed change is not robust. Rarely used SELECT parameters may appear after the ORDER BY parameters in which case they will be chewed up as parameters of ORDER BY. I don't know if anything beyond ORDER BY are supported. As https://dev.mysql.com/doc/refman/5.7/en/select.html