### PR TITLE
Changed trim to rtrim

### DIFF
--- a/wp-includes/fields_map.php
+++ b/wp-includes/fields_map.php
@@ -30,11 +30,11 @@ class Fields_map
         }
 
         if (!is_null($blogid)) {
-            $blog_filepath = trim(str_replace('mu-plugins/wp-db-abstraction/translations/sqlsrv', '', strtr(dirname(__FILE__), '\\', '/')), '/') . $loc . '/fields_map.parsed_types.' . $blogid . '.php';
+            $blog_filepath = rtrim(str_replace('mu-plugins/wp-db-abstraction/translations/sqlsrv', '', strtr(dirname(__FILE__), '\\', '/')), '/') . $loc . '/fields_map.parsed_types.' . $blogid . '.php';
 
             // if the file doesn't exist, we're going to grab our default file, read it in to get the "base" tables, then set our filepath differently again
             if (!file_exists($blog_filepath)) {
-                $this->filepath = trim(str_replace('mu-plugins/wp-db-abstraction/translations/sqlsrv', '', strtr(dirname(__FILE__), '\\', '/')), '/') . $loc . '/fields_map.parsed_types.php';
+                $this->filepath = rtrim(str_replace('mu-plugins/wp-db-abstraction/translations/sqlsrv', '', strtr(dirname(__FILE__), '\\', '/')), '/') . $loc . '/fields_map.parsed_types.php';
                 $this->read();
                 $this->filepath = $blog_filepath;
                 $this->update_for('');
@@ -42,9 +42,8 @@ class Fields_map
 
             $this->filepath = $blog_filepath;
         } else {
-            $this->filepath = trim(str_replace('mu-plugins/wp-db-abstraction/translations/sqlsrv', '', strtr(dirname(__FILE__), '\\', '/')), '/') . $loc . '/fields_map.parsed_types.php';
-    
-            // if the file doesn't exist yet, we'll try to write it out and blow up if we can't
+        	$this->filepath = rtrim(str_replace('mu-plugins/wp-db-abstraction/translations/sqlsrv', '', strtr(dirname(__FILE__), '\\', '/')), '/') . $loc . '/fields_map.parsed_types.php';
+    		// if the file doesn't exist yet, we'll try to write it out and blow up if we can't
             if (!file_exists($this->filepath)) {
                 $this->update_for('');
             }


### PR DESCRIPTION
This will stop the prepending slash from being removed during the install.

Tested on CentOS 7.2 with PHP 7.