### PR TITLE
MU Plugin to control Jetpack

### DIFF
--- a/wp-content/mu-plugins/pn-config.php
+++ b/wp-content/mu-plugins/pn-config.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * A place to store any miscellaneous config needed for Core or external plugin issues.
+ */
+
+/*
+ * Stop Jetpack from writing to options with direct DB calls.
+ */
+define( 'JETPACK_DISABLE_RAW_OPTIONS', true );

--- a/wp-content/mu-plugins/pn-config.php
+++ b/wp-content/mu-plugins/pn-config.php
@@ -7,4 +7,6 @@
 /*
  * Stop Jetpack from writing to options with direct DB calls.
  */
-define( 'JETPACK_DISABLE_RAW_OPTIONS', true );
+if ( ! defined( 'JETPACK_DISABLE_RAW_OPTIONS' ) ) {
+	define( 'JETPACK_DISABLE_RAW_OPTIONS', true );
+}


### PR DESCRIPTION
Adding in an MU Plugin to store settings needed to trigger actions in other plugins (or possibly even Core) which aid with compatibility.  Kicking this off with a setting which forces Jetpack to use the Options API rather than performing direct DB writes.