### PR TITLE
Non-numeric value set for $ord

### DIFF
--- a/wp-includes/translations.php
+++ b/wp-includes/translations.php
@@ -1254,7 +1254,7 @@ class SQL_Translations extends wpdb
     function translate_sort_casting($query)
     {
         if ( stripos($query, 'ORDER') > 0 ) {
-            $ord = '';
+            $ord = 0;
             $order_pos = stripos($query, 'ORDER');
             if ( stripos($query, 'BY', $order_pos) == ($order_pos + 6) && stripos($query, 'OVER(', $order_pos - 5) != ($order_pos - 5)) {
                 $ob = stripos($query, 'BY', $order_pos);


### PR DESCRIPTION
$ord was set to '' when it should really be 0. This fixes a PHP warning on line 1289 if $ord is not set by line 1262 or 1265.