### PR TITLE
Set $orderby_clause even when we don't have a SQL type for the meta query

### DIFF
--- a/wp-includes/class-wp-query.php
+++ b/wp-includes/class-wp-query.php
@@ -1508,8 +1508,8 @@ class WP_Query {
 				break;
 			case $primary_meta_key:
 			case 'meta_value':
+				$orderby_clause = "meta_value";
 				if ( ! empty( $primary_meta_query['type'] ) ) {
-					$orderby_clause = "meta_value";
 					$orderbyfields = $orderbyfields . ", CAST({$primary_meta_query['alias']}.meta_value AS {$sql_type}) as meta_value";
 				} else {
                     $orderbyfields = $orderbyfields . ", {$primary_meta_query['alias']}.meta_value";


### PR DESCRIPTION
If we're ordering by `meta_value` but `$primary_meta_query['type']` is not set, then `$orderby_clause` is never set, resulting in a PHP warning.

If we don't have a type set, chances are we can still do the ordering without a cast to the SQL type, so we should still set `$orderby_clause`, I think.