### PR TITLE
Move on_update_to_merge to before we reinstate our stripped strings

### DIFF
--- a/wp-includes/translations.php
+++ b/wp-includes/translations.php
@@ -321,17 +321,17 @@ class SQL_Translations extends wpdb
             }
         }
 
+        if ( $this->insert_query ) {
+            // $query = $this->on_duplicate_key($query);
+            // $query = $this->split_insert_values($query);
+            /* on_duplicate_key() and split_insert_values() functions may be deleted if on_update_to_merge() works properly. */
+            $query = $this->on_update_to_merge($query);
+        }
+        
         if (!empty($this->preg_data)) {
             $query = vsprintf($query, $this->preg_data);
         }
         $this->preg_data = array();
-
-        if ( $this->insert_query ) {
-            // $query = $this->on_duplicate_key($query);
-            // $query = $this->split_insert_values($query);
-			/* on_duplicate_key() and split_insert_values() functions may be deleted if on_update_to_merge() works properly. */
-			$query = $this->on_update_to_merge($query);
-        }
 
         return $query;
     }


### PR DESCRIPTION
Tentative fix for #327 - seems to do the right thing, but not sure if the original positioning was deliberate?