### PR TITLE
Strip out MySQL index hints

### DIFF
--- a/wp-includes/translations.php
+++ b/wp-includes/translations.php
@@ -307,6 +307,7 @@ class SQL_Translations extends wpdb
             'translate_create_queries',
             'translate_specific',
 			'translate_if_not_exists_insert_merge',
+            'translate_index_hints',
         );
 
         // Perform translations and record query changes.
@@ -2271,6 +2272,35 @@ class SQL_Translations extends wpdb
             return $query;
         }
         return $arr;
+    }
+
+    /**
+     * MySQL uses FORCE INDEX (columns) as a query index hint. T-SQL allows
+     * an equivalent WITH (INDEX (index_name)) query hint, but that uses the name
+     * of the index rather than the columns, which we don't have here, so just
+     * drop the hint instead.
+     * 
+     * TODO: Perhaps map known index names?
+     *
+     * @param string $query Query coming in
+     *
+     * @return string Translated Query
+     */
+    function translate_index_hints($query)
+    {
+        // Index hints are only used for SELECT queries
+        if (stripos($query, "SELECT") === false) {
+            return $query;
+        }
+        // Short-circuit this translation if there don't appear to be any query hints
+        if (stripos($query, "INDEX") === false && stripos($query, "KEY") === false) {
+            return $query;
+        }
+
+        // Pattern constructed from grammar at https://dev.mysql.com/doc/refman/8.0/en/index-hints.html
+        $query = preg_replace('/(FORCE|IGNORE|USE)\s+(INDEX|KEY)\s+(FOR.*)?\(.*\)/iU', "", $query);
+        
+        return $query;
     }
 
     /**


### PR DESCRIPTION
This removes MySQL-style query hints as described in #333.

It uses the grammar described at https://dev.mysql.com/doc/refman/8.0/en/index-hints.html, and covers `FORCE`, `IGNORE` and `USE` hints, though I've only seen `FORCE` used with bbPress.