### PR TITLE
Fix a Silent Error throwing for too many parameters

### DIFF
--- a/wp-admin/includes/template.php
+++ b/wp-admin/includes/template.php
@@ -692,7 +692,7 @@ function meta_form( $post = null ) {
 			WHERE meta_key NOT BETWEEN '_' AND '_z'
 			AND meta_key NOT LIKE %s
 			ORDER BY meta_key";
-		$keys  = $wpdb->get_col( $wpdb->prepare( $sql, $wpdb->esc_like( '_' ) . '%', $limit ) );
+		$keys  = $wpdb->get_col( $wpdb->prepare( $sql, $wpdb->esc_like( '_' ) . '%' ) );
 	}
 
 	if ( $keys ) {


### PR DESCRIPTION
Without this, trying to run Edit Page (possibly more places) would hit my **xDebug**ger and throw this error. Previously this was an issue for one of the other developers but since then we temporarily fixed it, and never got round to finishing it on here.
Error thrown would be: `The query does not contain the correct number of placeholders (%1$d) for the number of arguments passed (%2$d).` 

Reason for this issue is that the Limit is written into the string in the first place:
```php
SELECT TOP $limit meta_key
```