### PR TITLE
🔨 [PHP 7.4] Fixed warning for usage of Invalid Index

### DIFF
--- a/wp-includes/wp-db.php
+++ b/wp-includes/wp-db.php
@@ -14,7 +14,6 @@ require_once(dirname(__FILE__) . '/translations.php');
  * @since 0.71
  */
 define( 'EZSQL_VERSION', 'WP1.25' );
-
 /**
  * @since 0.71
  */
@@ -2605,7 +2604,7 @@ class wpdb {
 				return null;
 			
 			$row = sqlsrv_fetch_array( $result );
-			return $row[ 0 ];
+			return sqlsrv_has_rows( $result ) ? $row[ 0 ] : null;
 		}
 
 		if ( $query ) {


### PR DESCRIPTION
Fixed a Warning which can show up with the Edit Page screen (and potentially more) when a get_var returns back no rows and tries to access an invalid index within the Array.

This fix checks if the SQLSRV has returned back any rows, and will access the 0th row as expected, if not then it will return null as expected within the Documentation. (and likely what is returned already)

Fixes: #448 