### PR TITLE
Removes blog_version from Schema

### DIFF
--- a/wp-admin/includes/schema.php
+++ b/wp-admin/includes/schema.php
@@ -287,16 +287,6 @@ GO
 CREATE INDEX $wpdb->blogs" . "_IDX2 on $wpdb->blogs (lang_id)
 GO
 
-CREATE TABLE $wpdb->blog_versions (
-  blog_id int NOT NULL default 0,
-  db_version nvarchar(20) NOT NULL default '',
-  last_updated datetime2(0) NOT NULL default '0001-01-01 00:00:00',
-  constraint $wpdb->blog_versions" . "_PK PRIMARY KEY  (blog_id)
-)
-GO
-CREATE INDEX $wpdb->blog_versions" . "_IDX1 on $wpdb->blog_versions (db_version)
-GO
-
 CREATE TABLE $wpdb->blogmeta (
 	meta_id int NOT NULL identity(1,1),
 	blog_id int NOT NULL default 0,


### PR DESCRIPTION
Removes the Redudant Blog_version table from schema... this causes errors in the Upgrade screen as the wp-db no longer stores information for this table as it is now removed.

This can be Confirmed in the Normal Wordpress: https://github.com/WordPress/wordpress-develop/blob/6a5ff5aa03713469a97398d6c93b476d19719b08/src/wp-admin/includes/schema.php#L247-L264

Wordpress Ticket: https://core.trac.wordpress.org/ticket/19755
Wordpress PR: https://core.trac.wordpress.org/attachment/ticket/19755/19755.patch