### PR TITLE
add missing semicolon to `var` statement

### DIFF
--- a/wp-includes/class-wp-editor.php
+++ b/wp-includes/class-wp-editor.php
@@ -1694,7 +1694,7 @@ final class _WP_Editors {
 						}
 					}
 				}
-			}
+			};
 
 			if ( typeof tinymce !== 'undefined' ) {
 				if ( tinymce.Env.ie && tinymce.Env.ie < 11 ) {


### PR DESCRIPTION
This is to fix a syntax error we encountered on our site (www.sqlservercentral.com), where our server minifies all outgoing HTML - after minification, the `var` statement here runs into the following `if` and cause a syntax error, which results in the editor toolbar not rendering.