### PR TITLE
Update class-wpdb.php to support NVARCHAR

### DIFF
--- a/wp-includes/class-wpdb.php
+++ b/wp-includes/class-wpdb.php
@@ -1635,7 +1635,7 @@ class wpdb {
 						 */
 						|| ( '' === $format && '%' !== substr( $split_query[ $key - 1 ], -1, 1 ) )
 					) {
-						$placeholder = "'%" . $format . "s'";
+						$placeholder = "N'%" . $format . "s'";
 					}
 				}
 			}


### PR DESCRIPTION
This fixes #515 .

Add "N" prefix to quoted string substitution when preparing SQL for execution. This will change string literals to be interpreted as NVARCHAR (i.e. Unicode / UTF-16) instead of VARCHAR (i.e. an 8-bit encoding, which changes all characters not in the associated code page to "?"s).

**PLEASE NOTE:** I don't have time to test this fix. If it helps, there are some notes on what should be tested in PR #422 .
